### PR TITLE
Revert "VFS: make vfs_fstat() use f[get|put]_light()"

### DIFF
--- a/fs/stat.c
+++ b/fs/stat.c
@@ -57,13 +57,12 @@ EXPORT_SYMBOL(vfs_getattr);
 
 int vfs_fstat(unsigned int fd, struct kstat *stat)
 {
-	int fput_needed;
-	struct file *f = fget_light(fd, &fput_needed);
+	struct file *f = fget_raw(fd);
 	int error = -EBADF;
 
 	if (f) {
 		error = vfs_getattr(f->f_path.mnt, f->f_path.dentry, stat);
-		fput_light(f, fput_needed);
+		fput(f);
 	}
 	return error;
 }


### PR DESCRIPTION
This reverts commit 9b67aeff9256ad337e22b0f3b228b7ec01ff2a20.

This is needed to get TouchPad working with latest systemd version (Yocto Warrior).